### PR TITLE
Cherry-Pick: Add support for the gRPC server to listen on a unix domain socket

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -64,8 +64,9 @@ func (s *server) serve() error {
 	l := []net.Listener{}
 	var err error
 	for _, host := range strings.Split(s.hosts, ",") {
+		network, address := parseHost(host)
 		var lis net.Listener
-		lis, err = net.Listen("tcp", host)
+		lis, err = net.Listen(network, address)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"Topic": "grpc",
@@ -99,6 +100,14 @@ func (s *server) serve() error {
 	}
 	wg.Wait()
 	return nil
+}
+
+func parseHost(host string) (string, string) {
+	const unixScheme = "unix://"
+	if strings.HasPrefix(host, unixScheme) {
+		return "unix", host[len(unixScheme):]
+	}
+	return "tcp", host
 }
 
 func (s *server) ListPeer(r *api.ListPeerRequest, stream api.GobgpApi_ListPeerServer) error {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHost(t *testing.T) {
+	tsts := []struct {
+		name          string
+		host          string
+		expectNetwork string
+		expectAddr    string
+	}{
+		{
+			name:          "schemeless tcp host defaults to tcp",
+			host:          "127.0.0.1:50051",
+			expectNetwork: "tcp",
+			expectAddr:    "127.0.0.1:50051",
+		},
+		{
+			name:          "schemeless with only port defaults to tcp",
+			host:          ":50051",
+			expectNetwork: "tcp",
+			expectAddr:    ":50051",
+		},
+		{
+			name:          "unix socket",
+			host:          "unix:///var/run/gobgp.socket",
+			expectNetwork: "unix",
+			expectAddr:    "/var/run/gobgp.socket",
+		},
+	}
+
+	for _, tst := range tsts {
+		t.Run(tst.name, func(t *testing.T) {
+			gotNetwork, gotAddr := parseHost(tst.host)
+			assert.Equal(t, tst.expectNetwork, gotNetwork)
+			assert.Equal(t, tst.expectAddr, gotAddr)
+		})
+	}
+}


### PR DESCRIPTION
From: https://github.com/osrg/gobgp/pull/2407